### PR TITLE
create main public ip metallb shared-ip

### DIFF
--- a/common/contour-external/contour.argoapp.yaml
+++ b/common/contour-external/contour.argoapp.yaml
@@ -31,6 +31,8 @@ spec:
             envoy:
               service:
                 type: LoadBalancer
+                annotations:
+                  metallb.io/allow-shared-ip: "shared-sharedmain-ip"
               image:
                 registry: public.ecr.aws
                 repository: bitnami/envoy


### PR DESCRIPTION
Add the shared-ip annotation to the ip used by the contour public ip service to allow other services to use same ip for different ports.